### PR TITLE
Handle missing production and consumption OBIS codes

### DIFF
--- a/iometer/reading.py
+++ b/iometer/reading.py
@@ -95,15 +95,18 @@ class Reading:
             }
         )
 
-    def get_total_consumption(self) -> float:
+    def get_total_consumption(self) -> float | None:
         """Get total consumption in Wh."""
         register = self.meter.reading.get_register_by_obis(self.TOTAL_CONSUMPTION_OBIS)
-        return register.value if register else 0
+        return register.value if register else None
 
-    def get_total_production(self) -> float:
-        """Get total production in Wh."""
+    def get_total_production(self) -> float | None:
+        """Get total production in Wh.
+
+        Returns None if OBIS is not found, otherwise the value in Wh as float.
+        """
         register = self.meter.reading.get_register_by_obis(self.TOTAL_PRODUCTION_OBIS)
-        return register.value if register else 0
+        return register.value if register else None
 
     def get_current_power(self) -> float | None:
         """Get current power consumption in W.


### PR DESCRIPTION
This PR adds logic for handling missing production and consumption OBIS codes.

Currently the client returns 0 if the registers:
- "01-00:01.08.00*ff"
- "01-00:02.08.00*ff"

are not present. This behavior is correct, as a user might think that the value is 0, although it is not present.

Therefore we add a return value of None, when missing.


Additionally tests are added.