### PR TITLE
add no_status and no_reading exceptions

### DIFF
--- a/iometer/__init__.py
+++ b/iometer/__init__.py
@@ -1,7 +1,12 @@
 """Asynchronous Python client for IOmeter."""
 
 from .client import IOmeterClient
-from .exceptions import IOmeterConnectionError, IOmeterTimeoutError
+from .exceptions import (
+    IOmeterConnectionError,
+    IOmeterNoReadingsError,
+    IOmeterNoStatusError,
+    IOmeterTimeoutError,
+)
 from .reading import Reading
 from .status import Status
 
@@ -11,6 +16,8 @@ __all__ = [
     "IOmeterClient",
     "IOmeterConnectionError",
     "IOmeterTimeoutError",
+    "IOmeterNoReadingsError",
+    "IOmeterNoStatusError",
     "Reading",
     "Status",
 ]

--- a/iometer/exceptions.py
+++ b/iometer/exceptions.py
@@ -10,8 +10,12 @@ class IOmeterConnectionError(IOmeterError):
 
 
 class IOmeterTimeoutError(IOmeterError):
-    """IOmeter client and bridge timeout exception"""
+    """IOmeter client and bridge timeout exception."""
 
 
-class IOmeterParseError(IOmeterError):
-    """IOmeter parse exception."""
+class IOmeterNoReadingsError(IOmeterError):
+    """No readings available exception."""
+
+
+class IOmeterNoStatusError(IOmeterError):
+    """No status available exception."""


### PR DESCRIPTION
This PR add two new exception types. Both are returned when their respective resource returns a HTTP 404. In that case the IOmeter bridge is reachable, but can't return an answer.

When /v1/status returns HTTP 404,  `IOmeterNoStatusError` is thrown.
When /v1/reading returns HTTP 404,  `IOmeterNoReadingsError` is thrown.

Especially the second exception is very helpful in cases were the bridge returns no reading due to not being attached to a meter.